### PR TITLE
⬆️ Upgrade Transifex cli.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,7 @@ jobs:
         (cd mayavi; git fetch origin; git checkout master; git reset --hard origin/master; git branch -a)
         pip3 install -U pip setuptools
         pip3 install -r ./requirements.txt
+        curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash
     - name: update
       env:
         SPHINXINTL_TRANSIFEX_USERNAME: api

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 -e ./mayavi
 sphinx-intl[transifex]==2.0.1
-transifex-client==0.14.3
 vtk==9.2.2
 Sphinx==5.3.0


### PR DESCRIPTION
Subject: ⬆️ Upgrade Transifex cli.

### Feature or Bugfix
<!-- please choose -->
- Feature

### Purpose
- Upgrade Transifex CLI dependencies.

### Detail
- The deprecation period of API 2.0/2.5 and Transifex CLI is coming to an end. Calls to these APIs and any scripts that depend on them will not work after Nov 30, 2022. We highly recommend you migrate to newer versions before the sunset date.

### Relates
- https://github.com/transifex/cli