### PR TITLE
ci: downgrade Python from 3.13 to 3.12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.13"
+          python-version: "3.12"
       - name: Get Job URL
         uses: Tiryoh/gha-jobid-action@be260d8673c9211a84cdcf37794ebd654ba81eef
         id: jobs


### PR DESCRIPTION
mayavi's C extension (`tvtk/src/array_ext.c`) fails to build on Python 3.13. Downgrading to Python 3.12 resolves the build error.