### PR TITLE
Fix Dependabot PR failure: use github.token instead of PERSONAL_ACCESSTOKEN

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           persist-credentials: false
           submodules: true
-          token: ${{ secrets.PERSONAL_ACCESSTOKEN }}
+          token: ${{ github.token }}
       - name: Setup SSH
         uses: MrSquaare/ssh-setup-action@84a60849dca0e42e04b9b73f930036654e4672ab
         with:


### PR DESCRIPTION
Fixes #203